### PR TITLE
Update requirements

### DIFF
--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -1,3 +1,3 @@
-nameko>=2.12.0,<=2.14.1
-Django>=3.0.7,<=4.2.6
+nameko>=2.12.0
+Django>=3.0.7
 importlib-metadata<5.0

--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -1,1 +1,3 @@
-nameko==2.12.0
+nameko>=2.12.0,<=2.14.1
+Django>=3.0.7,<=4.2.6
+importlib-metadata<5.0

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,2 +1,0 @@
--r common.txt
-Django==3.0.7

--- a/setup.py
+++ b/setup.py
@@ -15,8 +15,9 @@ setuptools.setup(
     packages=['django_nameko_standalone'],
     platforms=['Linux'],
     install_requires=[
-        "Django==3.0.7",
-        "nameko==2.12.0"
+        "Django>=3.0.7,<=4.2.6",
+        "nameko>=2.12.0,<=2.14.1",
+        "importlib-metadata<5.0"
     ],
     test_suite='pytest',
     setup_requires=['pytest-runner'],
@@ -26,11 +27,11 @@ setuptools.setup(
     classifiers=[
         "Environment :: Web Environment",
         "Intended Audience :: Developers",
-        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: >=3.6.15",
         "License :: OSI Approved :: MIT License",
         "Operating System :: OS Independent",
         "Development Status :: 5 - Production/Stable",
-        "Framework :: Django :: 3.0",
+        "Framework :: Django :: >=3.0.7,<=4.2.6",
         "Topic :: Software Development :: Libraries",
     ],
 )

--- a/setup.py
+++ b/setup.py
@@ -15,9 +15,9 @@ setuptools.setup(
     packages=['django_nameko_standalone'],
     platforms=['Linux'],
     install_requires=[
-        "Django>=3.0.7,<=4.2.6",
-        "nameko>=2.12.0,<=2.14.1",
-        "importlib-metadata<5.0"
+        "Django>=3",
+        "nameko>=2.12",
+        "importlib-metadata<5"
     ],
     test_suite='pytest',
     setup_requires=['pytest-runner'],
@@ -31,7 +31,7 @@ setuptools.setup(
         "License :: OSI Approved :: MIT License",
         "Operating System :: OS Independent",
         "Development Status :: 5 - Production/Stable",
-        "Framework :: Django :: >=3.0.7,<=4.2.6",
+        "Framework :: Django :: >=3.0",
         "Topic :: Software Development :: Libraries",
     ],
 )

--- a/test_settings.py
+++ b/test_settings.py
@@ -1,4 +1,3 @@
 DJANGO_NAMEKO_STANDALONE_APPS = ("tests",)
 INSTALLED_APPS = ("tests",)
 SECRET_KEY = '<your_secret_key>'
-DATABASES = {}

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -1,6 +1,7 @@
 import os
 from unittest import TestCase
 
+import django
 from django_nameko_standalone import DjangoModels
 
 
@@ -11,10 +12,37 @@ class SetUpTestCase(TestCase):
         os.environ.setdefault("DJANGO_NAMEKO_STANDALONE_SETTINGS_MODULE", "test_settings")
         django_models = DjangoModels()
         django_models.setup()
+        django_version = django.VERSION
+        self.django_major_version = django_version[0]
+        self.django_minor_version = django_version[1]
 
     def test_set_up(self):
         from django.conf import settings
         self.assertTupleEqual(settings.DJANGO_NAMEKO_STANDALONE_APPS, ("tests",))
         self.assertTupleEqual(settings.INSTALLED_APPS, ("tests",))
         self.assertEqual(settings.SECRET_KEY, '<your_secret_key>')
-        self.assertDictEqual(settings.DATABASES, {})
+        expected_databases = {
+            'default': {
+                'ATOMIC_REQUESTS': False,
+                'AUTOCOMMIT': True,
+                'CONN_MAX_AGE': 0,
+                'ENGINE': 'django.db.backends.dummy',
+                'HOST': '',
+                'NAME': '',
+                'OPTIONS': {},
+                'PASSWORD': '',
+                'PORT': '',
+                'TEST': {
+                    'CHARSET': None,
+                    'COLLATION': None,
+                    'MIGRATE': True,
+                    'MIRROR': None,
+                    'NAME': None
+                },
+                'TIME_ZONE': None,
+                'USER': ''
+            }
+        }
+        if self.django_major_version >= 4 and self.django_minor_version > 0:
+            expected_databases['default']['CONN_HEALTH_CHECKS'] = False
+        self.assertDictEqual(settings.DATABASES, expected_databases)


### PR DESCRIPTION
Updated the common requirement file to support newer version of Django and Nameko, allowing to support newer python versions as well.

The unit tests are passing on python 3.6, 3.7, 3.8, 3.9, and 3.11.